### PR TITLE
Recognize CODE definitions

### DIFF
--- a/src/utils/definition_index.rs
+++ b/src/utils/definition_index.rs
@@ -664,4 +664,22 @@ mod tests {
         assert!(index.find_stack_effect("MYWORD").is_some());
         assert!(index.find_stack_effect("MyWord").is_some());
     }
+
+    #[test]
+    fn test_code_definition() {
+        let mut index = DefinitionIndex::new();
+        let temp_dir = env::temp_dir();
+        let file_path = temp_dir.join("test.forth").to_string_lossy().to_string();
+
+        index.update_file(
+            &file_path,
+            &Rope::from_str("CODE syscall0 MOV RAX RBX END-CODE\n: test syscall0 ;"),
+        );
+
+        let defs = index.find_definitions("syscall0");
+        assert_eq!(defs.len(), 1);
+
+        let refs = index.find_references("syscall0");
+        assert_eq!(refs.len(), 1);
+    }
 }

--- a/src/utils/definition_index.rs
+++ b/src/utils/definition_index.rs
@@ -110,6 +110,7 @@ impl DefinitionIndex {
             "FCONSTANT",
             "DEFER",
             "BUFFER:",
+            "CODE",
         ];
 
         for i in 0..tokens.len().saturating_sub(1) {

--- a/src/utils/diagnostics.rs
+++ b/src/utils/diagnostics.rs
@@ -650,4 +650,25 @@ mod tests {
         // Should not flag any usage of MyWord regardless of case
         assert_eq!(diagnostics.len(), 0);
     }
+
+    #[test]
+    fn test_code_definition_not_flagged() {
+        let rope = Rope::from_str("CODE syscall0 MOV RAX RBX END-CODE\n: test syscall0 ;");
+        let mut index = DefinitionIndex::new();
+        let temp_dir = env::temp_dir();
+        let file_path = temp_dir.join("test_code.forth").to_string_lossy().to_string();
+        index.update_file(&file_path, &rope);
+        let words = Words::default();
+
+        let diagnostics = check_undefined_words(&rope, &index, &words);
+
+        assert!(
+            !diagnostics.iter().any(|d| d.message.contains("syscall0")),
+            "syscall0 should not be flagged - defined via CODE"
+        );
+        assert!(
+            !diagnostics.iter().any(|d| d.message.contains("END-CODE")),
+            "END-CODE should not be flagged as undefined"
+        );
+    }
 }

--- a/src/utils/diagnostics.rs
+++ b/src/utils/diagnostics.rs
@@ -656,7 +656,10 @@ mod tests {
         let rope = Rope::from_str("CODE syscall0 MOV RAX RBX END-CODE\n: test syscall0 ;");
         let mut index = DefinitionIndex::new();
         let temp_dir = env::temp_dir();
-        let file_path = temp_dir.join("test_code.forth").to_string_lossy().to_string();
+        let file_path = temp_dir
+            .join("test_code.forth")
+            .to_string_lossy()
+            .to_string();
         index.update_file(&file_path, &rope);
         let words = Words::default();
 

--- a/src/utils/diagnostics.rs
+++ b/src/utils/diagnostics.rs
@@ -55,6 +55,7 @@ pub fn check_undefined_words_from_tokens(
         "fconstant",
         "defer",
         "buffer:",
+        "code",
     ];
     for i in 0..tokens.len().saturating_sub(1) {
         if let Token::Word(data) = &tokens[i]
@@ -93,6 +94,15 @@ pub fn check_undefined_words_from_tokens(
 
             // Skip words inside string literals
             if in_string_literal {
+                continue;
+            }
+
+            // Skip defining words and definition terminators
+            if defining_words
+                .iter()
+                .any(|&dw| dw.eq_ignore_ascii_case(data.value))
+                || data.value.eq_ignore_ascii_case("END-CODE")
+            {
                 continue;
             }
 

--- a/src/utils/handlers/request_semantic_tokens.rs
+++ b/src/utils/handlers/request_semantic_tokens.rs
@@ -33,7 +33,7 @@ const MODIFIER_DEFAULT_LIBRARY: u32 = 1 << 1;
 /// Control-flow words that should be highlighted as keywords
 const CONTROL_FLOW_WORDS: &[&str] = &[
     "IF", "THEN", "ELSE", "DO", "LOOP", "BEGIN", "UNTIL", "WHILE", "REPEAT", "CASE", "ENDCASE",
-    "OF", "ENDOF", "+LOOP", "DOES>", "EXIT", "LEAVE", "UNLOOP", "?DO", "RECURSE",
+    "OF", "ENDOF", "+LOOP", "DOES>", "EXIT", "LEAVE", "UNLOOP", "?DO", "RECURSE", "END-CODE",
 ];
 
 /// Defining words that should be highlighted as keywords
@@ -49,6 +49,7 @@ const DEFINING_WORDS: &[&str] = &[
     "FCONSTANT",
     "DEFER",
     "BUFFER:",
+    "CODE",
 ];
 
 fn is_control_flow_word(word: &str) -> bool {


### PR DESCRIPTION
Teach forth-lsp to recognize `CODE name ... END-CODE` definitions.

This fixes false undefined-word diagnostics for words defined with `CODE`, for example VFX Forth code like:

```forth
CODE syscall0    \ nr -- r
  MOV  RAX, RBX
  SYSCALL
  MOV  RBX, RAX
  NEXT,
END-CODE

: sys-gettid ( -- tid )
  SYS_gettid syscall0
;
```

Before this change, `syscall0` was not indexed as a definition, so later uses were reported as `Undefined word`.