### PR TITLE
fix: numbers can be part of words

### DIFF
--- a/lib/forth-lexer/src/parser.rs
+++ b/lib/forth-lexer/src/parser.rs
@@ -292,193 +292,10 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_number_underscore() {
-        let mut lexer = Lexer::new("10_000");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 6, "10_000"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_number_underscore_only_valid() {
-        let mut lexer = Lexer::new("_$10_000");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 8, "_$10_000"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_number_double_cell() {
-        let mut lexer = Lexer::new("12.34");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 5, "12.34"))];
-        assert_eq!(tokens, expected)
-    }
-    #[test]
-    fn test_parse_number_double_cell_only_valid() {
-        let mut lexer = Lexer::new("12.3.4");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 6, "12.3.4"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
     fn test_word_multi_byte_utf8() {
         let mut lexer = Lexer::new("👻");
         let tokens = lexer.parse();
         let expected = vec![Word(Data::new(0, 4, "👻"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_word_minus() {
-        let mut lexer = Lexer::new("-");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 1, "-"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_word_dollar_minus() {
-        let mut lexer = Lexer::new("$-");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 2, "$-"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_word_dollar() {
-        let mut lexer = Lexer::new("$");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 1, "$"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_word_neg_neg_one() {
-        let mut lexer = Lexer::new("--1");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 3, "--1"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_number_literal() {
-        let mut lexer = Lexer::new("12");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 2, "12"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_number_oct() {
-        let mut lexer = Lexer::new("&12");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 3, "&12"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_negative_number_literal() {
-        let mut lexer = Lexer::new("-12");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 3, "-12"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_negative_number_literal_zero() {
-        let mut lexer = Lexer::new("-01");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 3, "-01"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_negative_number_oct() {
-        let mut lexer = Lexer::new("&-7");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 3, "&-7"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_negative_number_bin() {
-        let mut lexer = Lexer::new("-%11");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 4, "-%11"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_number_bin() {
-        let mut lexer = Lexer::new("%0100101");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 8, "%0100101"))];
-        assert_eq!(tokens, expected);
-    }
-
-    #[test]
-    fn test_parse_number_bin_only_valid() {
-        let mut lexer = Lexer::new("%12345");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 6, "%12345"))];
-        assert_eq!(tokens, expected);
-    }
-
-    #[test]
-    fn test_parse_number_only_valid() {
-        let mut lexer = Lexer::new("2dup");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 4, "2dup"))];
-        assert_eq!(tokens, expected);
-    }
-
-    #[test]
-    fn test_parse_number_hex_only_valid() {
-        let mut lexer = Lexer::new("$cafefun");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 8, "$cafefun"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_number_hex() {
-        let mut lexer = Lexer::new("$FfAaDd");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 7, "$FfAaDd"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_number_0xhex() {
-        let mut lexer = Lexer::new("0xFE");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 4, "0xFE"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_negative_number_before_0xhex() {
-        let mut lexer = Lexer::new("-0xFE");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 5, "-0xFE"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_negative_number_after_0hex() {
-        let mut lexer = Lexer::new("0x-FE");
-        let tokens = lexer.parse();
-        let expected = vec![Number(Data::new(0, 5, "0x-FE"))];
-        assert_eq!(tokens, expected)
-    }
-
-    #[test]
-    fn test_parse_minus_only_valid() {
-        let mut lexer = Lexer::new("-0x-A-");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 6, "-0x-A-"))];
         assert_eq!(tokens, expected)
     }
 
@@ -534,14 +351,6 @@ mod tests {
         assert_eq!(tokens, expected)
     }
 
-    #[test]
-    fn test_parse_number_word() {
-        let mut lexer = Lexer::new("word");
-        let tokens = lexer.parse();
-        let expected = vec![Word(Data::new(0, 4, "word"))];
-        assert_eq!(tokens, expected)
-    }
-
     #[cfg(feature = "ropey")]
     #[test]
     fn test_to_ropey() {
@@ -557,5 +366,134 @@ mod tests {
         let x = rope.slice(&word2);
         assert_eq!("word2", word2.value);
         assert_eq!(word2.value, x);
+    }
+
+    const PREFIXES: [&'static str; 6] = ["$", "#", "&", "%", "0x", ""];
+
+    const DIGITS: [&'static str; 6] = [
+        "0123456789abcdef",
+        "012345789",
+        "012345679",
+        "01",
+        "0123456789ABCDEF",
+        "012345689",
+    ];
+
+    const NON_DIGITS: [&'static str; 6] = [
+        "0123456789abcdefg",
+        "012345789a",
+        "012345689a",
+        "012",
+        "0123456789ABCDEFG",
+        "012345689a",
+    ];
+
+    fn should_parse_number(s: String) {
+        let mut lexer = Lexer::new(&s);
+        let tokens = lexer.parse();
+        let expected = vec![Number(Data::new(0, s.len(), &s))];
+        assert_eq!(tokens, expected);
+    }
+
+    fn should_parse_word(s: String) {
+        let mut lexer = Lexer::new(&s);
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, s.len(), &s))];
+        assert_eq!(tokens, expected);
+    }
+
+    #[test]
+    fn test_parse_numbers() {
+        for (prefix, digits) in PREFIXES.iter().zip(DIGITS.iter()) {
+            should_parse_number(format!("{prefix}{digits}"));
+        }
+    }
+
+    #[test]
+    fn test_parse_numbers_sign() {
+        for (prefix, digits) in PREFIXES.iter().zip(DIGITS.iter()) {
+            // Sign in prefix
+            should_parse_number(format!("-{prefix}{digits}"));
+            should_parse_number(format!("{prefix}-{digits}"));
+        }
+    }
+
+    #[test]
+    fn test_parse_numbers_underscore() {
+        for (prefix, digits) in PREFIXES.iter().zip(DIGITS.iter()) {
+            // Underscore after prefix
+            should_parse_number(format!("{prefix}_{digits}_{digits}"));
+            should_parse_number(format!("{prefix}_")); // Zero
+        }
+    }
+
+    #[test]
+    fn test_parse_numbers_decimal_point() {
+        for (prefix, digits) in PREFIXES.iter().zip(DIGITS.iter()) {
+            // Decimal point after prefix
+            should_parse_number(format!("{prefix}.{digits}"));
+            should_parse_number(format!("{prefix}{digits}."));
+            should_parse_number(format!("{prefix}{digits}.{digits}"));
+        }
+    }
+
+    #[test]
+    fn test_parse_numbers_only_valid() {
+        for (prefix, bad_digits) in PREFIXES.iter().zip(NON_DIGITS.iter()) {
+            // Non-digits
+            should_parse_word(format!("{prefix}{bad_digits}"));
+        }
+    }
+
+    #[test]
+    fn test_parse_numbers_prefix_only_valid() {
+        for prefix in PREFIXES {
+            // Prefix without digits
+            if !prefix.is_empty() {
+                should_parse_word(format!("{prefix}"));
+            }
+            should_parse_word(format!("{prefix}-"));
+            should_parse_word(format!("-{prefix}"));
+            should_parse_word(format!("{prefix}-"));
+        }
+    }
+
+    #[test]
+    fn test_parse_numbers_sign_only_valid() {
+        for (prefix, digits) in PREFIXES.iter().zip(DIGITS.iter()) {
+            // Too many signs
+            should_parse_word(format!("--{prefix}{digits}"));
+            should_parse_word(format!("-{prefix}-{digits}"));
+            should_parse_word(format!("{prefix}-{digits}-{digits}"));
+            should_parse_word(format!("{prefix}--{digits}"));
+        }
+    }
+
+    #[test]
+    fn test_parse_numbers_underscore_only_valid() {
+        for (prefix, digits) in PREFIXES.iter().zip(DIGITS.iter()) {
+            // Underscore in prefix
+            if !prefix.is_empty() {
+                should_parse_word(format!("_{prefix}{digits}"));
+                should_parse_word(format!("{prefix}_-{digits}"));
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_numbers_decimal_point_only_valid() {
+        for (prefix, digits) in PREFIXES.iter().zip(DIGITS.iter()) {
+            // Decimal point before prefix
+            if !prefix.is_empty() {
+                should_parse_word(format!(".{prefix}{digits}"));
+            }
+
+            // Too many decimal points
+            should_parse_word(format!("{prefix}{digits}.{digits}.{digits}"));
+            should_parse_word(format!("{prefix}.{digits}.{digits}"));
+
+            // Decimal point without digits
+            should_parse_word(format!("{prefix}."));
+        }
     }
 }

--- a/lib/forth-lexer/src/parser.rs
+++ b/lib/forth-lexer/src/parser.rs
@@ -54,7 +54,7 @@ impl<'a> Lexer<'a> {
         self.token_start = self.position;
 
         let tok = match self.ch {
-            '0'..='9' | '-' | '$' | '#' | '&' | '%' => self.parse_number(),
+            '0'..='9' | '-' | '$' | '#' | '&' | '%' | '_' | '.' => self.parse_number(),
             '\'' => self.parse_quote(),
             ':' => match self.peek_char() {
                 c if is_whitespace(c) => Token::Colon(self.read_ident()),
@@ -103,10 +103,13 @@ impl<'a> Lexer<'a> {
         self.read_position += self.ch.len();
     }
 
-    fn read_digits(&mut self, radix: u32) {
+    fn read_digits(&mut self, radix: u32) -> usize {
+        let mut count = 0;
         while self.ch.is_digit(radix) || self.ch == '_' {
             self.read_char();
+            count += 1;
         }
+        count
     }
 
     fn parse_number(&mut self) -> Token<'a> {
@@ -137,23 +140,17 @@ impl<'a> Lexer<'a> {
             self.read_char();
         }
 
-        // Prefix followed by whitespace is Word
-        if is_whitespace(self.ch) {
-            return Token::Word(self.current_token_data());
-        }
-
-        self.read_digits(radix);
+        let mut digit_count = self.read_digits(radix);
 
         if self.ch == '.' {
             self.read_char();
-            self.read_digits(radix);
+            digit_count += self.read_digits(radix);
         }
 
         // Digits followed by whitespace is Number
-        if is_whitespace(self.ch) {
+        if digit_count > 0 && is_whitespace(self.ch) {
             Token::Number(self.current_token_data())
         } else {
-            // Digits followed by neither whitespace or digit is Word
             self.read_ident();
             Token::Word(self.current_token_data())
         }

--- a/lib/forth-lexer/src/parser.rs
+++ b/lib/forth-lexer/src/parser.rs
@@ -1,5 +1,7 @@
 use std::{iter::Peekable, str::Chars};
 
+use nom::AsChar;
+
 use crate::token::{Data, Token};
 
 pub enum LexError {}
@@ -98,7 +100,7 @@ impl<'a> Lexer<'a> {
         self.input.next();
 
         self.position = self.read_position;
-        self.read_position += 1;
+        self.read_position += self.ch.len();
     }
 
     fn parse_number(&mut self) -> Token<'a> {
@@ -277,6 +279,14 @@ mod tests {
             Word(Data::new(5, 10, "words")),
             Word(Data::new(11, 15, "here")),
         ];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_word_ut8() {
+        let mut lexer = Lexer::new("👻");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 4, "👻"))];
         assert_eq!(tokens, expected)
     }
 

--- a/lib/forth-lexer/src/parser.rs
+++ b/lib/forth-lexer/src/parser.rs
@@ -1,7 +1,5 @@
 use std::{iter::Peekable, str::Chars};
 
-use nom::AsChar;
-
 use crate::token::{Data, Token};
 
 pub enum LexError {}
@@ -9,6 +7,7 @@ pub enum LexError {}
 pub struct Lexer<'a> {
     position: usize,
     read_position: usize,
+    token_start: usize,
     ch: char,
     raw: &'a str,
     input: Peekable<Chars<'a>>,
@@ -19,6 +18,7 @@ impl<'a> Lexer<'a> {
         let mut lex = Lexer {
             position: 0,
             read_position: 0,
+            token_start: 0,
             ch: '0',
             input: input.chars().peekable(),
             raw: input,
@@ -26,12 +26,6 @@ impl<'a> Lexer<'a> {
         lex.read_char();
 
         lex
-    }
-
-    pub fn reset(&mut self) {
-        self.position = 0;
-        self.read_position = 0;
-        self.ch = '\0';
     }
 
     pub fn here(&self) -> Data<'a> {
@@ -42,32 +36,38 @@ impl<'a> Lexer<'a> {
         }
     }
 
+    fn current_token_data(&self) -> Data<'a> {
+        let start = self.token_start;
+        let end = self.position.min(self.raw.len());
+        Data {
+            start,
+            end,
+            value: &self.raw[start..end],
+        }
+    }
+
     pub fn next_token(&mut self) -> Result<Token<'a>, LexError> {
         self.skip_whitespace();
 
+        self.token_start = self.position;
+
         let tok = match self.ch {
-            ':' => Token::Colon(self.read_single_char_token()),
-            ';' => Token::Semicolon(self.read_single_char_token()),
-            '%' => self.try_parse_number_with_prefix(|c| c.is_digit(2)),
-            '&' => self.try_parse_number_with_prefix(|c| c == 'x' || c.is_digit(8)),
-            '$' => self.try_parse_number_with_prefix(|c| c.is_hex_digit()),
-            '\'' => self.parse_quote_or_word(),
-            '0' => self.try_parse_number_with_prefix(|c| c == 'x' || c.is_hex_digit()),
-            '0'..='9' => {
-                let ident = self.read_number();
-                Token::Number(ident)
-            }
-            '\\' => {
-                if self.peek_char().is_whitespace() {
-                    let comment = self.read_comment_to('\n');
-                    Token::Comment(comment)
-                } else {
-                    let ident = self.read_ident();
-                    Token::Word(ident)
-                }
-            }
-            '(' => {
-                if self.peek_char().is_whitespace() {
+            '0'..='9' | '-' | '$' | '#' | '&' | '%' => self.parse_number(),
+            '\'' => self.parse_quote(),
+            ':' => match self.peek_char() {
+                c if is_whitespace(c) => Token::Colon(self.read_ident()),
+                _ => Token::Word(self.read_ident()),
+            },
+            ';' => match self.peek_char() {
+                c if is_whitespace(c) => Token::Semicolon(self.read_ident()),
+                _ => Token::Word(self.read_ident()),
+            },
+            '\\' => match self.peek_char() {
+                c if is_whitespace(c) => Token::Comment(self.read_comment_to('\n')),
+                _ => Token::Word(self.read_ident()),
+            },
+            '(' => match self.peek_char() {
+                c if is_whitespace(c) => {
                     let comment = self.read_comment_to(')');
                     // Stack comments contain '--' to denote stack effects
                     if comment.value.contains("--") {
@@ -75,21 +75,15 @@ impl<'a> Lexer<'a> {
                     } else {
                         Token::Comment(comment)
                     }
-                } else {
-                    let ident = self.read_ident();
-                    Token::Word(ident)
                 }
-            }
+                _ => Token::Word(self.read_ident()),
+            },
             '\0' => {
                 let mut dat = self.here();
                 dat.value = "\0";
-                self.read_char();
                 Token::Eof(dat)
             }
-            _ => {
-                let ident = self.read_ident();
-                Token::Word(ident)
-            }
+            _ => Token::Word(self.read_ident()),
         };
 
         Ok(tok)
@@ -107,50 +101,69 @@ impl<'a> Lexer<'a> {
         self.read_position += 1;
     }
 
-    fn try_parse_number_with_prefix(&mut self, validator: fn(char) -> bool) -> Token<'a> {
-        if validator(self.peek_char()) {
-            Token::Number(self.read_number())
+    fn parse_number(&mut self) -> Token<'a> {
+        let mut sign_seen = false;
+
+        if self.ch == '-' {
+            self.read_char();
+            sign_seen = true;
+        }
+
+        let (prefix_len, radix) = match self.ch {
+            '$' => (1, 16),
+            '&' => (1, 8),
+            '%' => (1, 2),
+            '0' => match self.peek_char() {
+                'x' | 'X' => (2, 16),
+                _ => (0, 10),
+            },
+            // TODO: What about BASE?
+            _ => (0, 10),
+        };
+
+        for _ in 0..prefix_len {
+            self.read_char();
+        }
+
+        if !sign_seen && self.ch == '-' {
+            self.read_char();
+        }
+
+        // Prefix followed by whitespace is Word
+        if is_whitespace(self.ch) {
+            return Token::Word(self.current_token_data());
+        }
+
+        while self.ch.is_digit(radix) {
+            self.read_char();
+        }
+
+        // Digits followed by whitespace is Number
+        if is_whitespace(self.ch) {
+            Token::Number(self.current_token_data())
         } else {
-            Token::Word(self.read_ident())
+            // Digits followed by neither whitespace or digit is Word
+            self.read_ident();
+            Token::Word(self.current_token_data())
         }
     }
 
-    fn parse_quote_or_word(&mut self) -> Token<'a> {
-        let begin = self.position;
-        let next = self.peek_char();
-
-        if next.is_whitespace() {
+    fn parse_quote(&mut self) -> Token<'a> {
+        // ASSUMPTION: self.ch == '\''
+        if is_whitespace(self.peek_char()) {
             return Token::Word(self.read_ident());
         }
 
-        self.read_char(); // consume character after quote
+        self.read_char(); // Read character after '\''
+        self.read_char(); // and next character
 
-        if self.peek_char() == '\'' {
-            // Character literal like 'A'
-            self.read_char(); // consume closing quote
-            let number = Data {
-                start: begin,
-                end: self.position + 1,
-                value: &self.raw[begin..(self.position + 1)],
-            };
-            self.read_char(); // move past
-            return Token::Number(number);
-        }
-
-        // Quoted word
-        let mut word = self.read_ident();
-        word.start = begin;
-        word.value = &self.raw[begin..word.end];
-        Token::Word(word)
-    }
-
-    fn read_single_char_token(&mut self) -> Data<'a> {
-        let start = self.position;
-        self.read_char();
-        Data {
-            start,
-            end: start + 1,
-            value: &self.raw[start..start + 1],
+        if self.ch == '\'' && is_whitespace(self.peek_char()) {
+            self.read_char();
+            let data = self.current_token_data();
+            Token::Number(data)
+        } else {
+            let ident = self.read_ident();
+            Token::Word(ident)
         }
     }
 
@@ -162,13 +175,12 @@ impl<'a> Lexer<'a> {
     }
 
     fn skip_whitespace(&mut self) {
-        while self.ch.is_ascii_whitespace() {
+        while is_whitespace(self.ch) && self.ch != '\0' {
             self.read_char();
         }
     }
 
     fn read_comment_to(&mut self, to: char) -> Data<'a> {
-        let start = self.position;
         while self.ch != to && self.ch != '\0' {
             self.read_char();
         }
@@ -176,45 +188,14 @@ impl<'a> Lexer<'a> {
             self.read_char();
         }
 
-        let end = self.position.min(self.raw.len());
-        Data {
-            start,
-            end,
-            value: &self.raw[start..end],
-        }
+        self.current_token_data()
     }
 
     fn read_ident(&mut self) -> Data<'a> {
-        let start = self.position;
-        while !self.ch.is_whitespace() && self.ch != '\0' {
+        while !is_whitespace(self.ch) {
             self.read_char();
         }
-        let end = self.position.min(self.raw.len());
-        Data {
-            start,
-            end,
-            value: &self.raw[start..end],
-        }
-    }
-
-    fn read_number(&mut self) -> Data<'a> {
-        let start = self.position;
-        //TODO: parse legal forth numbers
-        while self.ch.is_hex_digit()
-            || self.ch == '_'
-            || self.ch == '&'
-            || self.ch == '%'
-            || self.ch == 'x'
-            || self.ch == '$'
-        {
-            self.read_char();
-        }
-        let end = self.position.min(self.raw.len());
-        Data {
-            start,
-            end,
-            value: &self.raw[start..end],
-        }
+        self.current_token_data()
     }
 
     pub fn parse(&mut self) -> Vec<Token<'a>> {
@@ -226,12 +207,16 @@ impl<'a> Lexer<'a> {
                     break;
                 }
                 _ => {
-                    tokens.push(tok.clone());
+                    tokens.push(tok);
                 }
             }
         }
         tokens
     }
+}
+
+fn is_whitespace(c: char) -> bool {
+    c.is_whitespace() || c.is_ascii_control()
 }
 
 #[cfg(test)]
@@ -296,6 +281,38 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_word_minus() {
+        let mut lexer = Lexer::new("-");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 1, "-"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_word_dollar_minus() {
+        let mut lexer = Lexer::new("$-");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 2, "$-"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_word_dollar() {
+        let mut lexer = Lexer::new("$");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 1, "$"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_word_neg_neg_one() {
+        let mut lexer = Lexer::new("--1");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 3, "--1"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
     fn test_parse_number_literal() {
         let mut lexer = Lexer::new("12");
         let tokens = lexer.parse();
@@ -312,6 +329,38 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_negative_number_literal() {
+        let mut lexer = Lexer::new("-12");
+        let tokens = lexer.parse();
+        let expected = vec![Number(Data::new(0, 3, "-12"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_negative_number_literal_zero() {
+        let mut lexer = Lexer::new("-01");
+        let tokens = lexer.parse();
+        let expected = vec![Number(Data::new(0, 3, "-01"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_negative_number_oct() {
+        let mut lexer = Lexer::new("&-7");
+        let tokens = lexer.parse();
+        let expected = vec![Number(Data::new(0, 3, "&-7"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_negative_number_bin() {
+        let mut lexer = Lexer::new("-%11");
+        let tokens = lexer.parse();
+        let expected = vec![Number(Data::new(0, 4, "-%11"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
     fn test_parse_number_bin() {
         let mut lexer = Lexer::new("%0100101");
         let tokens = lexer.parse();
@@ -320,14 +369,27 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_parse_number_bin_only_valid() {
-        //TODO: but ill formed will also parse
-        //      %12345 is not a binary number
         let mut lexer = Lexer::new("%12345");
         let tokens = lexer.parse();
         let expected = vec![Word(Data::new(0, 6, "%12345"))];
         assert_eq!(tokens, expected);
+    }
+
+    #[test]
+    fn test_parse_number_only_valid() {
+        let mut lexer = Lexer::new("2dup");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 4, "2dup"))];
+        assert_eq!(tokens, expected);
+    }
+
+    #[test]
+    fn test_parse_number_hex_only_valid() {
+        let mut lexer = Lexer::new("$cafefun");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 8, "$cafefun"))];
+        assert_eq!(tokens, expected)
     }
 
     #[test]
@@ -347,10 +409,42 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_negative_number_before_0xhex() {
+        let mut lexer = Lexer::new("-0xFE");
+        let tokens = lexer.parse();
+        let expected = vec![Number(Data::new(0, 5, "-0xFE"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_negative_number_after_0hex() {
+        let mut lexer = Lexer::new("0x-FE");
+        let tokens = lexer.parse();
+        let expected = vec![Number(Data::new(0, 5, "0x-FE"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_minus_only_valid() {
+        let mut lexer = Lexer::new("-0x-A-");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 6, "-0x-A-"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
     fn test_parse_number_char() {
         let mut lexer = Lexer::new("'c'");
         let tokens = lexer.parse();
         let expected = vec![Number(Data::new(0, 3, "'c'"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_number_char_only_valid() {
+        let mut lexer = Lexer::new("' '");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 1, "'")), Word(Data::new(2, 3, "'"))];
         assert_eq!(tokens, expected)
     }
 

--- a/lib/forth-lexer/src/parser.rs
+++ b/lib/forth-lexer/src/parser.rs
@@ -103,23 +103,29 @@ impl<'a> Lexer<'a> {
         self.read_position += self.ch.len();
     }
 
+    fn read_digits(&mut self, radix: u32) {
+        while self.ch.is_digit(radix) || self.ch == '_' {
+            self.read_char();
+        }
+    }
+
     fn parse_number(&mut self) -> Token<'a> {
-        let mut sign_seen = false;
+        let mut accept_sign = true;
 
         if self.ch == '-' {
             self.read_char();
-            sign_seen = true;
+            accept_sign = false;
         }
 
         let (prefix_len, radix) = match self.ch {
             '$' => (1, 16),
-            '&' => (1, 8),
             '%' => (1, 2),
+            '#' => (1, 10),
+            '&' => (1, 10),
             '0' => match self.peek_char() {
                 'x' | 'X' => (2, 16),
                 _ => (0, 10),
             },
-            // TODO: What about BASE?
             _ => (0, 10),
         };
 
@@ -127,7 +133,7 @@ impl<'a> Lexer<'a> {
             self.read_char();
         }
 
-        if !sign_seen && self.ch == '-' {
+        if accept_sign && self.ch == '-' {
             self.read_char();
         }
 
@@ -136,8 +142,11 @@ impl<'a> Lexer<'a> {
             return Token::Word(self.current_token_data());
         }
 
-        while self.ch.is_digit(radix) {
+        self.read_digits(radix);
+
+        if self.ch == '.' {
             self.read_char();
+            self.read_digits(radix);
         }
 
         // Digits followed by whitespace is Number
@@ -283,7 +292,38 @@ mod tests {
     }
 
     #[test]
-    fn test_word_ut8() {
+    fn test_parse_number_underscore() {
+        let mut lexer = Lexer::new("10_000");
+        let tokens = lexer.parse();
+        let expected = vec![Number(Data::new(0, 6, "10_000"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_number_underscore_only_valid() {
+        let mut lexer = Lexer::new("_$10_000");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 8, "_$10_000"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_parse_number_double_cell() {
+        let mut lexer = Lexer::new("12.34");
+        let tokens = lexer.parse();
+        let expected = vec![Number(Data::new(0, 5, "12.34"))];
+        assert_eq!(tokens, expected)
+    }
+    #[test]
+    fn test_parse_number_double_cell_only_valid() {
+        let mut lexer = Lexer::new("12.3.4");
+        let tokens = lexer.parse();
+        let expected = vec![Word(Data::new(0, 6, "12.3.4"))];
+        assert_eq!(tokens, expected)
+    }
+
+    #[test]
+    fn test_word_multi_byte_utf8() {
         let mut lexer = Lexer::new("👻");
         let tokens = lexer.parse();
         let expected = vec![Word(Data::new(0, 4, "👻"))];

--- a/src/utils/definition_index.rs
+++ b/src/utils/definition_index.rs
@@ -56,15 +56,7 @@ impl DefinitionIndex {
             if result.len() >= 2 {
                 // Mark the word name token(s) as part of definition
                 if let Token::Number(num_data) = &result[1] {
-                    if let Some(Token::Word(word_data)) = result.get(2) {
-                        if num_data.end == word_data.start {
-                            // Combined name like "2SWAP" - mark both tokens
-                            definition_token_indices.insert(num_data.start);
-                            definition_token_indices.insert(word_data.start);
-                        }
-                    } else {
-                        definition_token_indices.insert(num_data.start);
-                    }
+                    definition_token_indices.insert(num_data.start);
                 } else if let Token::Word(data) = &result[1] {
                     definition_token_indices.insert(data.start);
                 }
@@ -142,18 +134,37 @@ impl DefinitionIndex {
 
         // Second pass: collect references (word usages)
         for token in tokens {
-            if let Token::Word(data) = token {
-                // Skip if this is a word name in a definition
-                if definition_token_indices.contains(&data.start) {
-                    continue;
+            match token {
+                Token::Word(data) => {
+                    if definition_token_indices.contains(&data.start) {
+                        continue;
+                    }
+
+                    let range = data.to_range(rope);
+
+                    self.references
+                        .entry(data.value.to_lowercase())
+                        .or_default()
+                        .push((file_path.to_string(), range));
                 }
+                Token::Number(data) => {
+                    if definition_token_indices.contains(&data.start) {
+                        continue;
+                    }
 
-                let range = data.to_range(rope);
+                    let name = data.value.to_lowercase();
 
-                self.references
-                    .entry(data.value.to_lowercase())
-                    .or_default()
-                    .push((file_path.to_string(), range));
+                    // Only add referene if first pass picked up number literal redefine
+                    if self.definitions.contains_key(&name) {
+                        let range = data.to_range(rope);
+
+                        self.references
+                            .entry(data.value.to_lowercase())
+                            .or_default()
+                            .push((file_path.to_string(), range));
+                    }
+                }
+                _ => {}
             }
         }
     }

--- a/src/utils/handlers/request_semantic_tokens.rs
+++ b/src/utils/handlers/request_semantic_tokens.rs
@@ -114,34 +114,8 @@ pub fn get_semantic_tokens(rope: &Rope, builtin_words: &Words) -> SemanticTokens
             Token::Semicolon(_) => (TOKEN_TYPE_KEYWORD, 0u32, false),
             Token::Comment(_) => (TOKEN_TYPE_COMMENT, 0u32, false),
             Token::StackComment(_) => (TOKEN_TYPE_STRING, 0u32, false),
-            Token::Number(num_data) => {
+            Token::Number(_num_data) => {
                 if after_colon {
-                    // Check if this number is part of a combined name like "2swap"
-                    if let Some(Token::Word(word_data)) = tokens.get(i + 1)
-                        && num_data.end == word_data.start
-                    {
-                        // Combined token: emit as single FUNCTION+DEFINITION
-                        let (line, start_char) = to_line_char(num_data.start, rope);
-                        let length = (word_data.end - num_data.start) as u32;
-                        let delta_line = line - prev_line;
-                        let delta_start = if delta_line == 0 {
-                            start_char - prev_start
-                        } else {
-                            start_char
-                        };
-                        semantic_tokens.push(SemanticToken {
-                            delta_line,
-                            delta_start,
-                            length,
-                            token_type: TOKEN_TYPE_FUNCTION,
-                            token_modifiers_bitset: MODIFIER_DEFINITION,
-                        });
-                        prev_line = line;
-                        prev_start = start_char;
-                        after_colon = false;
-                        i += 2; // skip both number and word
-                        continue;
-                    }
                     // Just a number as the definition name
                     after_colon = false;
                     (TOKEN_TYPE_FUNCTION, MODIFIER_DEFINITION, false)

--- a/src/utils/token_utils.rs
+++ b/src/utils/token_utils.rs
@@ -4,8 +4,7 @@ use forth_lexer::token::Token;
 
 /// Extract a word name from a token sequence starting at the given index.
 ///
-/// Handles three cases:
-/// - Number followed by Word with no gap = combined name (e.g., 2SWAP)
+/// Handles two cases:
 /// - Single Word token
 /// - Single Number token (valid Forth word name)
 ///
@@ -16,17 +15,11 @@ pub fn extract_word_name(tokens: &[Token], index: usize) -> Option<String> {
         return None;
     }
 
-    match (&tokens[index], tokens.get(index + 1)) {
-        // Number followed by Word with no gap = combined name (e.g., 2SWAP)
-        (Token::Number(num_data), Some(Token::Word(word_data)))
-            if num_data.end == word_data.start =>
-        {
-            Some(format!("{}{}", num_data.value, word_data.value))
-        }
+    match &tokens[index] {
         // Just a Word
-        (Token::Word(data), _) => Some(data.value.to_string()),
+        Token::Word(data) => Some(data.value.to_string()),
         // Just a Number (valid Forth word name)
-        (Token::Number(data), _) => Some(data.value.to_string()),
+        Token::Number(data) => Some(data.value.to_string()),
         _ => None,
     }
 }
@@ -43,21 +36,11 @@ pub fn extract_word_name_with_range(
         return None;
     }
 
-    match (&tokens[index], tokens.get(index + 1)) {
-        // Number followed by Word with no gap = combined name (e.g., 2SWAP)
-        (Token::Number(num_data), Some(Token::Word(word_data)))
-            if num_data.end == word_data.start =>
-        {
-            Some((
-                format!("{}{}", num_data.value, word_data.value),
-                num_data.start,
-                word_data.end,
-            ))
-        }
+    match &tokens[index] {
         // Just a Word
-        (Token::Word(data), _) => Some((data.value.to_string(), data.start, data.end)),
+        Token::Word(data) => Some((data.value.to_string(), data.start, data.end)),
         // Just a Number (valid Forth word name)
-        (Token::Number(data), _) => Some((data.value.to_string(), data.start, data.end)),
+        Token::Number(data) => Some((data.value.to_string(), data.start, data.end)),
         _ => None,
     }
 }


### PR DESCRIPTION
Fix string slicing runtime panics by counting read bytes instead of read chars to not end up in invalid utf8 code points.

Rewrite number parsing. Before the change, some words would get tokenized as numbers (`%12345`), or part number part word (`2dup`), for example. 