### PR TITLE
fix: correct byte offset used as char offset for multibyte files

### DIFF
--- a/src/utils/diagnostics.rs
+++ b/src/utils/diagnostics.rs
@@ -225,19 +225,17 @@ pub fn check_unmatched_delimiters_from_source(text: &str, rope: &Rope) -> Vec<Di
     let mut paren_depth = 0;
     let mut paren_start: Option<usize> = None;
 
-    for (i, ch) in text.char_indices() {
+    for (byte_offset, ch) in text.char_indices() {
         if ch == '(' {
             if paren_depth == 0 {
-                paren_start = Some(i);
+                paren_start = Some(byte_offset);
             }
             paren_depth += 1;
         } else if ch == ')' {
             if paren_depth == 0 {
                 // Unmatched closing paren
-                let pos = Position {
-                    line: rope.char_to_line(i) as u32,
-                    character: (i - rope.line_to_char(rope.char_to_line(i))) as u32,
-                };
+                let (line, character) = to_line_char(byte_offset, rope);
+                let pos = Position { line, character };
                 diagnostics.push(Diagnostic {
                     range: Range {
                         start: pos,
@@ -265,10 +263,8 @@ pub fn check_unmatched_delimiters_from_source(text: &str, rope: &Rope) -> Vec<Di
     if paren_depth > 0
         && let Some(start) = paren_start
     {
-        let start_pos = Position {
-            line: rope.char_to_line(start) as u32,
-            character: (start - rope.line_to_char(rope.char_to_line(start))) as u32,
-        };
+        let (line, character) = to_line_char(start, rope);
+        let start_pos = Position { line, character };
         diagnostics.push(Diagnostic {
             range: Range {
                 start: start_pos,
@@ -676,5 +672,81 @@ mod tests {
             !diagnostics.iter().any(|d| d.message.contains("END-CODE")),
             "END-CODE should not be flagged as undefined"
         );
+    }
+
+    #[test]
+    fn test_unmatched_paren_after_multibyte_chars_does_not_crash() {
+        // Regression: char_indices() returns byte offsets, but they were
+        // passed to char_to_line() which expects char offsets. With enough
+        // multi-byte chars the byte offset exceeds len_chars() → panic.
+        let prefix: String = std::iter::repeat('è').take(100).collect();
+        let src = format!("{}\n)", prefix);
+        let rope = Rope::from_str(&src);
+        let diagnostics = check_unmatched_delimiters_from_source(&src, &rope);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("Unmatched closing parenthesis")),
+        );
+    }
+
+    #[test]
+    fn test_unclosed_paren_after_multibyte_chars_does_not_crash() {
+        let prefix: String = std::iter::repeat('è').take(100).collect();
+        let src = format!("{}\n( unclosed", prefix);
+        let rope = Rope::from_str(&src);
+        let diagnostics = check_unmatched_delimiters_from_source(&src, &rope);
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("Unclosed parenthesis")),
+        );
+    }
+
+    #[test]
+    fn test_unmatched_paren_position_after_multibyte_char() {
+        // "\ è\n)" — the ')' is on line 1, character 0.
+        // Before the fix, byte offset 5 was used as char offset,
+        // giving a wrong (or panicking) position.
+        let src = "\\ è\n)";
+        let rope = Rope::from_str(src);
+        let diagnostics = check_unmatched_delimiters_from_source(src, &rope);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].range.start.line, 1);
+        assert_eq!(diagnostics[0].range.start.character, 0);
+    }
+
+    #[test]
+    fn test_unclosed_paren_position_after_multibyte_char() {
+        // "\ è\n( open" — the '(' is on line 1, character 0.
+        let src = "\\ è\n( open";
+        let rope = Rope::from_str(src);
+        let diagnostics = check_unmatched_delimiters_from_source(src, &rope);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].range.start.line, 1);
+        assert_eq!(diagnostics[0].range.start.character, 0);
+    }
+
+    #[test]
+    fn test_unmatched_paren_position_same_line_as_multibyte() {
+        // "è )" — the ')' is on line 0, character 2 (not byte 3).
+        let src = "è )";
+        let rope = Rope::from_str(src);
+        let diagnostics = check_unmatched_delimiters_from_source(src, &rope);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].range.start.line, 0);
+        assert_eq!(diagnostics[0].range.start.character, 2);
+    }
+
+    #[test]
+    fn test_diagnostics_multibyte_utf8_full_pipeline() {
+        // Full diagnostics pipeline with multi-byte UTF-8 (Italian text)
+        let src = "\\ tabella è unica\r\n: SAVE ( -- ) ;\r\n\\ così il test\r\n";
+        let rope = Rope::from_str(src);
+        let mut index = DefinitionIndex::new();
+        let file_uri = "file:///test/test.f".to_string();
+        index.update_file(&file_uri, &rope);
+        let words = Words::default();
+        let _ = get_diagnostics(&rope, &index, &words);
     }
 }

--- a/src/utils/handlers/notification_did_change.rs
+++ b/src/utils/handlers/notification_did_change.rs
@@ -39,10 +39,17 @@ pub fn handle_did_change_text_document(
                 );
                 if let Some(range) = change.range {
                     // Incremental change - update specific range
-                    let start = rope.line_to_char(range.start.line as usize)
+                    let start_line = range.start.line as usize;
+                    let end_line = range.end.line as usize;
+                    if start_line >= rope.len_lines() || end_line >= rope.len_lines() {
+                        // Out-of-bounds range, fall back to full document sync
+                        *rope = Rope::from_str(change.text.as_str());
+                        continue;
+                    }
+                    let start = rope.line_to_char(start_line)
                         + range.start.character as usize;
                     let end =
-                        rope.line_to_char(range.end.line as usize) + range.end.character as usize;
+                        rope.line_to_char(end_line) + range.end.character as usize;
                     rope.remove(start..end);
                     rope.insert(start, change.text.as_str());
                 } else {

--- a/src/utils/handlers/request_code_action.rs
+++ b/src/utils/handlers/request_code_action.rs
@@ -155,6 +155,10 @@ pub fn get_code_actions(
         let end_line = range.end.line as usize;
         let end_char = range.end.character as usize;
 
+        if start_line >= rope.len_lines() || end_line >= rope.len_lines() {
+            return actions;
+        }
+
         // Extract selected text
         let start_idx = rope.line_to_char(start_line) + start_char;
         let end_idx = rope.line_to_char(end_line) + end_char;

--- a/src/utils/handlers/request_hover.rs
+++ b/src/utils/handlers/request_hover.rs
@@ -368,4 +368,45 @@ mod tests {
             panic!("Expected Markup hover contents");
         }
     }
+
+    #[test]
+    fn test_hover_multibyte_utf8_file() {
+        use crate::utils::definition_index::DefinitionIndex;
+        use crate::utils::ropey::word_on_or_before::WordOnOrBefore;
+        use ropey::Rope;
+
+        // Simulate a Forth file with Italian comments (multi-byte UTF-8)
+        let src = "\\ tabella è unica\r\n: SAVE_BATT ( -- ) ;\r\n\\ così il test\r\n";
+        let rope = Rope::from_str(src);
+
+        let mut index = DefinitionIndex::new();
+        let file_uri = "file:///test/test.f".to_string();
+        index.update_file(&file_uri, &rope);
+
+        let mut files = HashMap::new();
+        files.insert(file_uri, rope.clone());
+        let words = Words::default();
+
+        for line in 0..rope.len_lines() {
+            let line_start = rope.line_to_char(line);
+            let line_end = if line + 1 < rope.len_lines() {
+                rope.line_to_char(line + 1)
+            } else {
+                rope.len_chars()
+            };
+            let line_len = line_end - line_start;
+            for character in [0, line_len / 2, line_len.saturating_sub(1)] {
+                let ix = line_start + character;
+                if ix < rope.len_chars() {
+                    let word = rope.word_on_or_before(ix);
+                    let _ = get_hover_result(
+                        &word.to_string(),
+                        &words,
+                        Some(&index),
+                        Some(&files),
+                    );
+                }
+            }
+        }
+    }
 }

--- a/src/utils/ropey/get_ix.rs
+++ b/src/utils/ropey/get_ix.rs
@@ -7,21 +7,32 @@ pub trait GetIx<T> {
 
 impl GetIx<CompletionParams> for Rope {
     fn get_ix(&self, params: &CompletionParams) -> usize {
-        self.line_to_char(params.text_document_position.position.line as usize)
-            + params.text_document_position.position.character as usize
+        let line = params.text_document_position.position.line as usize;
+        if line >= self.len_lines() {
+            return self.len_chars();
+        }
+        self.line_to_char(line) + params.text_document_position.position.character as usize
     }
 }
 
 impl GetIx<HoverParams> for Rope {
     fn get_ix(&self, params: &HoverParams) -> usize {
-        self.line_to_char(params.text_document_position_params.position.line as usize)
+        let line = params.text_document_position_params.position.line as usize;
+        if line >= self.len_lines() {
+            return self.len_chars();
+        }
+        self.line_to_char(line)
             + params.text_document_position_params.position.character as usize
     }
 }
 
 impl GetIx<GotoTypeDefinitionParams> for Rope {
     fn get_ix(&self, params: &GotoTypeDefinitionParams) -> usize {
-        self.line_to_char(params.text_document_position_params.position.line as usize)
+        let line = params.text_document_position_params.position.line as usize;
+        if line >= self.len_lines() {
+            return self.len_chars();
+        }
+        self.line_to_char(line)
             + params.text_document_position_params.position.character as usize
     }
 }
@@ -111,5 +122,78 @@ mod tests {
         // line 1: "  1 2 3\n" = 8 chars (total 15)
         // line 2: ";" starts at char 15
         assert_eq!(rope.get_ix(&params), 15);
+    }
+
+    fn make_hover(line: u32, character: u32) -> HoverParams {
+        HoverParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: "file:///test.forth".parse().unwrap(),
+                },
+                position: Position { line, character },
+            },
+            work_done_progress_params: Default::default(),
+        }
+    }
+
+    fn make_completion(line: u32, character: u32) -> CompletionParams {
+        CompletionParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: "file:///test.forth".parse().unwrap(),
+                },
+                position: Position { line, character },
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+            context: None,
+        }
+    }
+
+    fn make_goto(line: u32, character: u32) -> GotoTypeDefinitionParams {
+        GotoTypeDefinitionParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: "file:///test.forth".parse().unwrap(),
+                },
+                position: Position { line, character },
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_get_ix_hover_line_out_of_bounds() {
+        let rope = Rope::from_str("one line");
+        // line 5 doesn't exist — should return len_chars, not panic
+        assert_eq!(rope.get_ix(&make_hover(5, 0)), rope.len_chars());
+    }
+
+    #[test]
+    fn test_get_ix_completion_line_out_of_bounds() {
+        let rope = Rope::from_str("one line");
+        assert_eq!(rope.get_ix(&make_completion(5, 0)), rope.len_chars());
+    }
+
+    #[test]
+    fn test_get_ix_goto_line_out_of_bounds() {
+        let rope = Rope::from_str("one line");
+        assert_eq!(rope.get_ix(&make_goto(5, 0)), rope.len_chars());
+    }
+
+    #[test]
+    fn test_get_ix_empty_rope() {
+        let rope = Rope::from_str("");
+        assert_eq!(rope.get_ix(&make_hover(0, 0)), rope.len_chars());
+        assert_eq!(rope.get_ix(&make_completion(0, 0)), rope.len_chars());
+        assert_eq!(rope.get_ix(&make_goto(0, 0)), rope.len_chars());
+    }
+
+    #[test]
+    fn test_get_ix_line_just_past_end() {
+        // Rope with 2 lines (0 and 1); line 2 is out of bounds
+        let rope = Rope::from_str("line0\nline1");
+        assert_eq!(rope.get_ix(&make_hover(2, 0)), rope.len_chars());
     }
 }


### PR DESCRIPTION
As discussed in #36 , fix attempt number 2 (was able to reproduce with è, ì, fixed in local tests)