### PR TITLE
fix(completion): suppress completions inside comments

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -624,9 +624,8 @@ mod tests {
             extensions: default_forth_extensions(),
             exclude: patterns.iter().map(|s| s.to_string()).collect(),
         };
-        let excluded = |patterns: &[&str], name: &str| {
-            ws(patterns).is_excluded(&Path::new("/p").join(name))
-        };
+        let excluded =
+            |patterns: &[&str], name: &str| ws(patterns).is_excluded(&Path::new("/p").join(name));
 
         assert!(excluded(&["target"], "target"));
         assert!(!excluded(&["target"], "targets"));

--- a/src/utils/handlers/request_completion.rs
+++ b/src/utils/handlers/request_completion.rs
@@ -12,11 +12,31 @@ use crate::{
 
 use std::collections::{HashMap, HashSet};
 
+use forth_lexer::{parser::Lexer, token::Token};
 use lsp_server::{Connection, Request};
 use lsp_types::{CompletionItem, CompletionResponse, request::Completion};
 use ropey::Rope;
 
 use super::cast;
+
+/// True if `char_ix` (a char index into `rope`) sits inside a comment.
+///
+/// Forth uses `\ ...` line comments and `( ... )` comments, and both are single
+/// tokens spanning their whole text — so a `:` (or any word) typed inside one is
+/// part of the comment, not code. We suppress completions there. The comment's
+/// end offset is treated inclusively so completions are also suppressed when the
+/// cursor is appended to the very end of a comment (the report in #41).
+fn position_in_comment(rope: &Rope, char_ix: usize) -> bool {
+    let char_ix = char_ix.min(rope.len_chars());
+    let byte_ix = rope.char_to_byte(char_ix);
+    let source = rope.to_string();
+    Lexer::new(&source).parse().iter().any(|tok| {
+        matches!(tok, Token::Comment(_) | Token::StackComment(_)) && {
+            let data = tok.get_data();
+            data.start <= byte_ix && byte_ix <= data.end
+        }
+    })
+}
 
 // Extract completion logic for testing
 pub fn get_completions(
@@ -177,6 +197,12 @@ pub fn handle_completion(
             if ix >= rope.len_chars() {
                 return Err(Error::OutOfBounds(ix));
             }
+            // Don't offer completions inside comments (e.g. a `:` typed in a
+            // `\ ...` or `( ... )` comment is prose, not a colon definition).
+            if position_in_comment(rope, ix) {
+                send_response(connection, id, None::<CompletionResponse>)?;
+                return Ok(());
+            }
             if let Some(char_at_ix) = rope.get_char(ix)
                 && char_at_ix.is_whitespace()
                 && ix > 0
@@ -211,6 +237,51 @@ pub fn handle_completion(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Char index just past the last occurrence of `needle` in `text`.
+    fn after(text: &str, needle: &str) -> usize {
+        let byte = text.rfind(needle).expect("needle present") + needle.len();
+        Rope::from_str(text).byte_to_char(byte)
+    }
+
+    #[test]
+    fn test_position_in_comment_line_comment() {
+        let text = "\\ make a thing : like this\n: real dup * ;\n";
+        let rope = Rope::from_str(text);
+        // A colon typed inside the line comment is not code.
+        assert!(position_in_comment(&rope, after(text, "thing :")));
+        // The real definition's colon on the next line is code.
+        assert!(!position_in_comment(&rope, after(text, ": real")));
+    }
+
+    #[test]
+    fn test_position_in_comment_paren_and_stack() {
+        let text = ": foo ( a -- b ) dup ;\n( note the : here )\n";
+        let rope = Rope::from_str(text);
+        // Inside a stack comment.
+        assert!(position_in_comment(&rope, after(text, "a --")));
+        // Inside a plain paren comment, on the colon.
+        assert!(position_in_comment(&rope, after(text, "the :")));
+        // The word after the stack comment is code.
+        assert!(!position_in_comment(&rope, after(text, "dup")));
+    }
+
+    #[test]
+    fn test_position_in_comment_appending_at_end() {
+        // Cursor sits at the very end of a line comment the user just typed a
+        // colon into (no trailing newline yet) — the #41 scenario.
+        let text = "\\ make a thing :";
+        let rope = Rope::from_str(text);
+        assert!(position_in_comment(&rope, rope.len_chars()));
+    }
+
+    #[test]
+    fn test_position_in_comment_plain_code_is_false() {
+        let text = ": square dup * ;\n";
+        let rope = Rope::from_str(text);
+        assert!(!position_in_comment(&rope, after(text, "dup")));
+        assert!(!position_in_comment(&rope, after(text, ": squ")));
+    }
 
     #[test]
     fn test_completion_finds_matching_words() {

--- a/tests/repro_issue_41.rs
+++ b/tests/repro_issue_41.rs
@@ -1,0 +1,165 @@
+//! Reproduction attempt for issue #41:
+//! "forth-lsp auto-appends a semicolon when you type a colon inside a comment"
+//!
+//! This drives the real server binary over stdio exactly like an editor would:
+//! initialize, open a document that contains a `:` inside a comment, then ask
+//! for the things an editor asks for as you type — completion at the colon and
+//! a full document formatting. We then inspect everything the server sends back
+//! and check whether any of it would insert a stray `;`.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+
+fn frame(msg: &str) -> String {
+    format!("Content-Length: {}\r\n\r\n{}", msg.len(), msg)
+}
+
+fn send(stdin: &mut ChildStdin, msg: &str) {
+    stdin.write_all(frame(msg).as_bytes()).unwrap();
+    stdin.flush().unwrap();
+}
+
+/// Read one Content-Length framed message; None on EOF.
+fn read_message(reader: &mut impl BufRead) -> Option<String> {
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).ok()? == 0 {
+            return None;
+        }
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some(rest) = trimmed.strip_prefix("Content-Length:") {
+            content_length = rest.trim().parse().ok()?;
+        }
+    }
+    let mut buf = vec![0u8; content_length];
+    reader.read_exact(&mut buf).ok()?;
+    Some(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Read messages until one whose body contains `needle` (an `"id":N` marker),
+/// collecting every message seen along the way.
+fn read_until(reader: &mut impl BufRead, needle: &str, collected: &mut Vec<String>) -> String {
+    for _ in 0..50 {
+        match read_message(reader) {
+            Some(msg) => {
+                let hit = msg.contains(needle);
+                collected.push(msg.clone());
+                if hit {
+                    return msg;
+                }
+            }
+            None => break,
+        }
+    }
+    panic!("did not receive a message containing {needle}");
+}
+
+fn shutdown(child: &mut Child, stdin: &mut ChildStdin) {
+    send(stdin, r#"{"jsonrpc":"2.0","id":99,"method":"shutdown"}"#);
+    send(stdin, r#"{"jsonrpc":"2.0","method":"exit"}"#);
+    let _ = child.wait();
+}
+
+#[test]
+fn typing_colon_inside_a_comment_does_not_append_semicolon() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_forth-lsp"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn forth-lsp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    // 1. initialize / initialized
+    send(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{},"workspaceFolders":null}}"#,
+    );
+    let mut seen = Vec::new();
+    read_until(&mut stdout, r#""id":1"#, &mut seen);
+    send(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","method":"initialized","params":{}}"#,
+    );
+
+    // 2. Open a doc with a `:` inside both a line comment and a paren comment.
+    //    The colon on line 0 sits inside a `\` line comment; line 1 puts one
+    //    inside a `( ... )` comment. A real definition on line 2 is the control.
+    let uri = "file:///tmp/repro41.forth";
+    let text = "\\ make a thing : like this\n( note the : here ) \n: real dup * ;\n";
+    let did_open = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": { "uri": uri, "languageId": "forth", "version": 1, "text": text }
+        }
+    })
+    .to_string();
+    send(&mut stdin, &did_open);
+
+    // 3. Completion right after the `:` typed inside the line comment
+    //    (line 0, character 16 — just past the colon).
+    let completion = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/completion",
+        "params": {
+            "textDocument": { "uri": uri },
+            "position": { "line": 0, "character": 16 }
+        }
+    })
+    .to_string();
+    send(&mut stdin, &completion);
+    let completion_resp = read_until(&mut stdout, r#""id":2"#, &mut seen);
+
+    // 4. Full-document formatting — the other path that can rewrite text.
+    let formatting = serde_json::json!({
+        "jsonrpc": "2.0", "id": 3, "method": "textDocument/formatting",
+        "params": {
+            "textDocument": { "uri": uri },
+            "options": { "tabSize": 2, "insertSpaces": true }
+        }
+    })
+    .to_string();
+    send(&mut stdin, &formatting);
+    let formatting_resp = read_until(&mut stdout, r#""id":3"#, &mut seen);
+
+    shutdown(&mut child, &mut stdin);
+
+    eprintln!("--- completion response ---\n{completion_resp}");
+    eprintln!("--- formatting response ---\n{formatting_resp}");
+
+    // Completions must be suppressed entirely inside a comment: the result is
+    // null (or, defensively, an empty list with no item that inserts a `;`).
+    let completion: serde_json::Value = serde_json::from_str(&completion_resp).unwrap();
+    let result = &completion["result"];
+    if let Some(items) = result.as_array() {
+        assert!(
+            items.is_empty(),
+            "expected no completions inside a comment, got: {result}"
+        );
+    } else {
+        assert!(
+            result.is_null(),
+            "expected null completion result inside a comment, got: {result}"
+        );
+    }
+
+    // Formatting must not turn a comment-embedded colon into a `: ... ;` def.
+    let formatting: serde_json::Value = serde_json::from_str(&formatting_resp).unwrap();
+    if let Some(edits) = formatting["result"].as_array() {
+        for edit in edits {
+            let new_text = edit["newText"].as_str().unwrap_or("");
+            // The one legitimate `;` is the real definition on line 2.
+            let semicolons = new_text.matches(';').count();
+            assert_eq!(
+                semicolons, 1,
+                "formatting introduced extra semicolons; output was:\n{new_text}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Refs #41.

## Problem

forth-lsp offered word/colon completions even when the cursor was inside a comment. Typing a `:` inside a `\ …` line comment or `( … )` comment popped up `:` / `:NONAME` suggestions, as if starting a colon definition. That's wrong on its own, and it's very likely *why* #41 looks server-driven — the suggestion popup appears in the comment, and a client-side auto-closing pair (`:` → `;`) from a Forth grammar extension then inserts the semicolon.

To be clear about scope: this does **not** insert or remove any `;` — the server never did that (verified separately: completion returns bare labels, formatting never synthesizes a `;`, and there's no on-type-formatting provider). This fixes the misleading completions that made the behavior *look* like forth-lsp.

## Change

`handle_completion` now lexes the document and, if the cursor's byte offset falls inside a `Comment` or `StackComment` token, returns no completions and bails early. The comment's end offset is treated inclusively, so completions are suppressed even when the cursor is appended to the very end of a comment (the exact #41 keystroke).

Completion in real code is unaffected — a word being typed right after a stack comment on the same line (`: foo ( a -- b ) du|`) still completes, because the cursor is past the comment token.

## Tests

- Unit tests for `position_in_comment`: line comments, paren/stack comments, appending at the end of a comment, and negative cases in plain code.
- `tests/repro_issue_41.rs` — an end-to-end regression test that spawns the real binary over stdio, opens a doc with `:` inside line and paren comments, and asserts (a) completion is empty inside the comment and (b) formatting introduces no extra semicolons.

256 unit tests + integration test pass; `cargo clippy --all-targets` clean.